### PR TITLE
fix adventure

### DIFF
--- a/idleloops-predictor.user.js
+++ b/idleloops-predictor.user.js
@@ -708,6 +708,12 @@ const Koviko = {
        */
       let total = 0;
 
+        /**
+        * Manna from adventure guild
+        * @var {number}
+        */
+       let deltaAdventure = 0;
+
       /**
        * Total time used for the action list
        * @var {number}
@@ -770,19 +776,15 @@ const Koviko = {
 
             // Only for Adventure Guild
             if ( listedAction.name == "Adventure Guild" ) {
-              state.resources.mana -= state.resources.adventures * 200;
-            }
+              deltaAdventure = state.resources.adventures * 200;
+            } else deltaAdventure = 0;
 
             // Calculate the total amount of mana used in the prediction and add it to the total
             total += currentMana - state.resources.mana;
 
-            // Only for Adventure Guild
-            if ( listedAction.name == "Adventure Guild" ) {
-              state.resources.mana += state.resources.adventures * 200;
-            }
 
             // Calculate time spent
-            let temp = (currentMana - state.resources.mana) / Math.pow(1 + getSkillLevel("Chronomancy") / 60, 0.25);
+            let temp = (currentMana - state.resources.mana + deltaAdventure) / Math.pow(1 + getSkillLevel("Chronomancy") / 60, 0.25);
             if ( state.resources.town === 0 && getBuffLevel("Ritual") > 0) {
               temp /= (1 + Math.min(getBuffLevel("Ritual"), 20) / 10);
             }


### PR DESCRIPTION
the guild of adventures does not correctly affect the time of the action list
There is a time calculation error associated with the adventure guild. Guild reduces the total time that is not correct. An example in the picture. Solution in pull request
![ti-error1](https://user-images.githubusercontent.com/17743692/51314711-7b0b5180-1a61-11e9-9849-3642f14b6006.png)
![ti-error2](https://user-images.githubusercontent.com/17743692/51314715-7cd51500-1a61-11e9-98c6-3cc9429a85c6.png)

